### PR TITLE
Extended to accept attributes for the format string with tests

### DIFF
--- a/NSAttributedStringFormat/NSAttributedString+CCLFormat.h
+++ b/NSAttributedStringFormat/NSAttributedString+CCLFormat.h
@@ -11,11 +11,27 @@
 + (instancetype)attributedStringWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
 
 /** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
+ @param attributes A dictionary of attributes for the format string. May be nil.
+ @param format A format string. This value must not be nil.
+ @param arguments list of arguments to substitute into format.
+ @return An attributed string created by using format as a template into which the remaining argument values are substituted.
+ */
++ (instancetype)attributedStringWithAttributes:(NSDictionary *)attributes format:(NSString *)format, ... NS_FORMAT_FUNCTION(2,3);
+
+/** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
  @param format A format string. This value must not be nil.
  @param arguments list of arguments to substitute into format.
  @return An attributed string created by using format as a template into which the remaining argument values are substituted.
  */
 + (instancetype)attributedStringWithFormat:(NSString *)format arguments:(va_list)arguments NS_FORMAT_FUNCTION(1,0);
+
+/** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
+ @param attributes A dictionary of attributes for the format string. May be nil.
+ @param format A format string. This value must not be nil.
+ @param arguments list of arguments to substitute into format.
+ @return An attributed string created by using format as a template into which the remaining argument values are substituted.
+ */
++ (instancetype)attributedStringWithAttributes:(NSDictionary *)attributes format:(NSString *)format arguments:(va_list)arguments NS_FORMAT_FUNCTION(2,0);
 
 /** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
  @param format A format string. This value must not be nil.
@@ -25,10 +41,27 @@
 - (instancetype)initWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
 
 /** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
+ @param attributes A dictionary of attributes for the format string. May be nil.
+ @param format A format string. This value must not be nil.
+ @param ... A comma-separated list of arguments to substitute into format.
+ @return An attributed string created by using format as a template into which the remaining argument values are substituted.
+ */
+- (instancetype)initWithAttributes:(NSDictionary *)attributes format:(NSString *)format, ... NS_FORMAT_FUNCTION(2,3);
+
+/** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
  @param format A format string. This value must not be nil.
  @param arguments list of arguments to substitute into format.
  @return An attributed string created by using format as a template into which the remaining argument values are substituted.
  */
 - (instancetype)initWithFormat:(NSString *)format arguments:(va_list)arguments NS_FORMAT_FUNCTION(1,0);
+
+/** Returns an attributed string created by using a given format string as a template into which the remaining argument values are substituted.
+ @param attributes A dictionary of attributes for the format string. May be nil.
+ @param format A format string. This value must not be nil.
+ @param arguments list of arguments to substitute into format.
+ @return An attributed string created by using format as a template into which the remaining argument values are substituted.
+ */
+- (instancetype)initWithAttributes:(NSDictionary *)attributes format:(NSString *)format arguments:(va_list)arguments NS_FORMAT_FUNCTION(2,0);
+
 
 @end

--- a/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
+++ b/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
@@ -157,10 +157,17 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
 
         if ([arg isKindOfClass:[NSAttributedString class]]) {
             if (attributes) {
+                //Copy to main string attributes over the argument copy
                 NSMutableAttributedString *argCopy = [arg mutableCopy];
-                NSMutableDictionary *newAttributes = [attributes mutableCopy];
-                [newAttributes addEntriesFromDictionary:[arg attributesAtIndex:0 effectiveRange:NULL]];
-                [argCopy setAttributes:newAttributes range:(NSRange){0, argCopy.length}];
+                [argCopy setAttributes:attributes range:(NSRange){0, argCopy.length}];
+                
+                //Re-apply the original attributes to keep orignal styling where necessary
+                //This handles cases where original styling doesn't cover the whole argument
+                //For example, repeat calls to attributedStringWithFormat: with styled arguments
+                [arg enumerateAttributesInRange:(NSRange){0, [arg length]} options:0 usingBlock:
+                 ^(NSDictionary<NSString *,id> * _Nonnull attrs, NSRange range, BOOL * _Nonnull stop) {
+                     [argCopy addAttributes:attrs range:range];
+                 }];
                 arg = argCopy;
             }
             [attributedString replaceCharactersInRange:parseResult.range withAttributedString:arg];

--- a/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
+++ b/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
@@ -156,6 +156,13 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
         id arg = [attributeStrings objectAtIndex:parseResult.index];
 
         if ([arg isKindOfClass:[NSAttributedString class]]) {
+            if (attributes) {
+                NSMutableAttributedString *argCopy = [arg mutableCopy];
+                NSMutableDictionary *newAttributes = [attributes mutableCopy];
+                [newAttributes addEntriesFromDictionary:[arg attributesAtIndex:0 effectiveRange:NULL]];
+                [argCopy setAttributes:newAttributes range:(NSRange){0, argCopy.length}];
+                arg = argCopy;
+            }
             [attributedString replaceCharactersInRange:parseResult.range withAttributedString:arg];
         } else {
             [attributedString replaceCharactersInRange:parseResult.range withString:[arg description]];

--- a/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
+++ b/NSAttributedStringFormat/NSAttributedString+CCLFormat.m
@@ -91,8 +91,21 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
     return result;
 }
 
++ (instancetype)attributedStringWithAttributes:(NSDictionary *)attributes format:(NSString *)format, ... NS_FORMAT_FUNCTION(2,3) {
+    va_list args;
+    va_start(args, format);
+    NSAttributedString *result = [[self alloc] initWithAttributes:attributes format:format arguments:args];
+    va_end(args);
+
+    return result;
+}
+
 + (instancetype)attributedStringWithFormat:(NSString *)format arguments:(va_list)arguments {
     return [[self alloc] initWithFormat:format arguments:arguments];
+}
+
++ (instancetype)attributedStringWithAttributes:(NSDictionary *)attributes format:(NSString *)format arguments:(va_list)arguments {
+    return [[self alloc] initWithAttributes:attributes format:format arguments:arguments];
 }
 
 - (instancetype)initWithFormat:(NSString *)format, ... {
@@ -104,8 +117,27 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
     return self;
 }
 
-- (instancetype)initWithFormat:(NSString *)format arguments:(va_list)args {
-    NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:format];
+- (instancetype)initWithAttributes:(NSDictionary *)attributes format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    self = [self initWithAttributes:attributes format:format arguments:args];
+    va_end(args);
+
+    return self;
+}
+
+- (instancetype)initWithFormat:(NSString *)format arguments:(va_list)arguments {
+    return [self initWithAttributes:nil format:format arguments:arguments];
+}
+
+- (instancetype)initWithAttributes:(NSDictionary *)attributes format:(NSString *)format arguments:(va_list)arguments {
+    NSMutableAttributedString *attributedString;
+    if (attributes) {
+        attributedString = [[NSMutableAttributedString alloc] initWithString:format attributes:attributes];
+    } else {
+        attributedString = [[NSMutableAttributedString alloc] initWithString:format];
+    }
+
     [attributedString beginEditing];
 
     NSUInteger maxPosition;
@@ -114,14 +146,14 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
         return lhs.range.location < rhs.range.location;
     }];
 
-    NSMutableArray *attributes = [NSMutableArray array];
+    NSMutableArray *attributeStrings = [NSMutableArray array];
     for (NSUInteger index = 0; index < maxPosition; ++index) {
-        id argument = va_arg(args, id);
-        [attributes addObject:argument];
+        id argument = va_arg(arguments, id);
+        [attributeStrings addObject:argument];
     }
 
     for (CCLFormatParseResult *parseResult in parseResults) {
-        id arg = [attributes objectAtIndex:parseResult.index];
+        id arg = [attributeStrings objectAtIndex:parseResult.index];
 
         if ([arg isKindOfClass:[NSAttributedString class]]) {
             [attributedString replaceCharactersInRange:parseResult.range withAttributedString:arg];
@@ -134,5 +166,6 @@ NSArray *CCLFormatStringParser(NSString *format, NSUInteger *maxPosition) {
 
     return [self initWithAttributedString:attributedString];
 }
+
 
 @end

--- a/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
+++ b/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
@@ -210,7 +210,7 @@
     NSMutableAttributedString *formattedAttributedString = [[NSMutableAttributedString alloc]
                                                             initWithString:@"test red bold blue red"
                                                             attributes:rootAttributes];
-    [formattedAttributedString setAttributes:redAttrs range:(NSRange){5, 17}];
+    [formattedAttributedString addAttributes:redAttrs range:(NSRange){5, 17}];
     [formattedAttributedString setAttributes:boldBlueAttrs range:(NSRange){9, 9}];
 
     XCTAssertEqualObjects(formattedAttributedString, attributedString);

--- a/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
+++ b/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
@@ -141,6 +141,58 @@
     XCTAssertEqualObjects([attributedString string], @"1 2 1", "");
 }
 
+- (void)testFormatStringCanHaveAttributes {
+    NSAttributedString *attributedString = [NSAttributedString attributedStringWithAttributes:@{
+                                            NSForegroundColorAttributeName: [NSColor blueColor]
+                                            } format:@"test %@", @"test"];
+    NSAttributedString *formattedAttributedString = [[NSAttributedString alloc] initWithString:@"test test"
+                    attributes:@{NSForegroundColorAttributeName: [NSColor blueColor]}];
+    XCTAssertEqualObjects(formattedAttributedString, attributedString);
+}
+
+- (void)testArgumentAttributesOverrideBaseAttributes {
+    NSAttributedString *attributedArg = [[NSAttributedString alloc] initWithString:@"test"
+                            attributes:@{NSForegroundColorAttributeName: [NSColor greenColor]}];
+    NSAttributedString *attributedString = [NSAttributedString attributedStringWithAttributes:@{
+                                NSForegroundColorAttributeName: [NSColor blueColor]
+                                } format:@"test %@", attributedArg];
+    NSMutableAttributedString *formattedAttributedString = [[NSMutableAttributedString alloc]
+                                initWithString:@"test "
+                                    attributes:@{NSForegroundColorAttributeName: [NSColor blueColor]}];
+    [formattedAttributedString appendAttributedString:attributedArg];
+    XCTAssertEqualObjects(formattedAttributedString, attributedString);
+}
+
+- (void)testMissingAttributeInAttributedArgumentUsesBaseAttribute {
+    NSAttributedString *attributedArg = [[NSAttributedString alloc] initWithString:@"test"
+                        attributes:@{NSForegroundColorAttributeName: [NSColor greenColor]}];
+    NSAttributedString *attributedString = [NSAttributedString attributedStringWithAttributes:@{
+                        NSForegroundColorAttributeName: [NSColor blueColor],
+                        NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0f]
+                        } format:@"test %@", attributedArg];
+    NSMutableAttributedString *formattedAttributedString = [[NSMutableAttributedString alloc]
+                                    initWithString:@"test " attributes:@{
+                            NSForegroundColorAttributeName: [NSColor blueColor],
+                            NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0f]
+                            }];
+    [formattedAttributedString appendAttributedString:attributedArg];
+    [formattedAttributedString addAttributes:@{
+                                               NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0f]
+                                               }
+                                       range:(NSRange) {5,4}];
+    XCTAssertEqualObjects(formattedAttributedString, attributedString);
+}
+
+- (void)testNonAttributedArgumentUsesBaseAttributes {
+    NSAttributedString *attributedString = [NSAttributedString attributedStringWithAttributes:@{
+                     NSForegroundColorAttributeName: [NSColor blueColor]
+                     } format:@"test %@", @"test"];
+    NSMutableAttributedString *formattedAttributedString = [[NSMutableAttributedString alloc]
+                                initWithString:@"test test" attributes:@{
+                                NSForegroundColorAttributeName: [NSColor blueColor]}];
+    XCTAssertEqualObjects(formattedAttributedString, attributedString);
+}
+
 - (void)testSubstituteAttributedStringPerformance {
     NSDictionary *attributes = @{ NSStrikethroughStyleAttributeName: @(NSUnderlineStyleSingle) };
     NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:@"Hi" attributes:attributes];

--- a/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
+++ b/NSAttributedStringFormatTests/NSAttributedString+CCLFormatTests.m
@@ -193,6 +193,29 @@
     XCTAssertEqualObjects(formattedAttributedString, attributedString);
 }
 
+- (void)testAttributedArgumentWithComplexAttributesKeepsAttributes {
+    NSDictionary *boldBlueAttrs = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0f],
+                                     NSForegroundColorAttributeName: [NSColor blueColor]};
+    NSDictionary *redAttrs = @{NSForegroundColorAttributeName: [NSColor redColor]};
+    NSDictionary *rootAttributes = @{NSForegroundColorAttributeName: [NSColor greenColor],
+                                     NSFontAttributeName: [NSFont systemFontOfSize:14.0f]};
+    
+    NSAttributedString *attributedArg = [NSAttributedString attributedStringWithAttributes:redAttrs
+                                                                                    format:@"red %@ red",
+                                         [[NSAttributedString alloc] initWithString:@"bold blue"
+                                                                         attributes:boldBlueAttrs]];
+
+    NSAttributedString *attributedString = [NSAttributedString attributedStringWithAttributes:rootAttributes
+                                                                    format:@"test %@", attributedArg];
+    NSMutableAttributedString *formattedAttributedString = [[NSMutableAttributedString alloc]
+                                                            initWithString:@"test red bold blue red"
+                                                            attributes:rootAttributes];
+    [formattedAttributedString setAttributes:redAttrs range:(NSRange){5, 17}];
+    [formattedAttributedString setAttributes:boldBlueAttrs range:(NSRange){9, 9}];
+
+    XCTAssertEqualObjects(formattedAttributedString, attributedString);
+}
+
 - (void)testSubstituteAttributedStringPerformance {
     NSDictionary *attributes = @{ NSStrikethroughStyleAttributeName: @(NSUnderlineStyleSingle) };
     NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:@"Hi" attributes:attributes];


### PR DESCRIPTION
Close #2. Updated @johnswan code for the current version.

Now the format string can have attributes independent of the attributed
parameter strings.